### PR TITLE
Hotfix/form dropdown search cache

### DIFF
--- a/src/components/FormDropdownSearch/FormDropdownSearch.test.ts
+++ b/src/components/FormDropdownSearch/FormDropdownSearch.test.ts
@@ -164,6 +164,29 @@ describe('searchValueDisplayed', () => {
         expect(wrapper.vm.searchValueDisplayed).toEqual('display me');
     });
 
+    it('is equal to modelValue label when searchValueCached is disabled', () => {
+        const modelValue = ref(items[0]);
+
+        const wrapper = shallowMount(FormDropdownSearch, {props: {
+            disableSearchCache: true,
+            modelValue,
+        }});
+
+        wrapper.vm.searchValue = 'display me';
+
+        expect(wrapper.vm.searchValueDisplayed).toEqual(modelValue.value.label);
+    });
+
+    it('is equal to searchValue when searchValueCached is disabled and modelValue is undefined', () => {
+        const wrapper = shallowMount(FormDropdownSearch, {props: {
+            disableSearchCache: true,
+        }});
+
+        wrapper.vm.searchValue = 'display me';
+
+        expect(wrapper.vm.searchValueDisplayed).toEqual('display me');
+    });
+
     it('resets searchValueCached, and model value and it sets searchValue', () => {
         const wrapper = shallowMount(FormDropdownSearch);
 

--- a/src/components/FormDropdownSearch/FormDropdownSearch.test.ts
+++ b/src/components/FormDropdownSearch/FormDropdownSearch.test.ts
@@ -172,7 +172,7 @@ describe('searchValueDisplayed', () => {
             modelValue,
         }});
 
-        wrapper.vm.searchValue = 'display me';
+        wrapper.vm.searchValue = 'do not display me';
 
         expect(wrapper.vm.searchValueDisplayed).toEqual(modelValue.value.label);
     });

--- a/src/components/FormDropdownSearch/FormDropdownSearch.vue
+++ b/src/components/FormDropdownSearch/FormDropdownSearch.vue
@@ -136,9 +136,17 @@ const modelValue = computed({
 const searchValueCached = ref<string>('');
 
 const searchValueDisplayed = computed({
-    get: () => searchValueCached.value !== ''
-        ? searchValueCached.value
-        : searchValue.value,
+    get: () => {
+        if (props.disableSearchCache) {
+            return modelValue.value
+                ? modelValue.value[props.labelKey]
+                : searchValue.value;
+        }
+
+        return searchValueCached.value !== ''
+            ? searchValueCached.value
+            : searchValue.value;
+    },
     set: s => {
         searchValueCached.value = '';
 


### PR DESCRIPTION
When `disableSearchCache` was enabled, it would not set the displayed search value properly... Didn't test it properly enough.

Now it's tested better ~~and hopefully fixed~~