### PR TITLE
fix(Rollup): Build default to UMD and add module build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
     "version": "0.22.1",
     "license": "MIT",
     "homepage": "https://owowagency.github.io/bootstrap-vue",
-    "main": "bootstrap-vue.mjs",
+    "entry": "bootstrap-vue",
+    "main": "bootstrap-vue.js",
+    "module": "bootstrap-vue.mjs",
     "publishConfig": {
         "@owowagency:registry": "https://npm.pkg.github.com"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import vue from 'rollup-plugin-vue';
 
 const createEntry = (options) => {
     return {
-        file: `dist/${options.file}`,
+        file: `dist/${pkg.entry}${options.extension || '.js'}`,
         format: options.format,
         globals: {
             vue: 'Vue',
@@ -25,7 +25,8 @@ export default {
     ],
     input: 'src/index.ts',
     output: [
-        createEntry({format: 'es', file: pkg.main}),
+        createEntry({format: 'umd'}),
+        createEntry({format: 'esm', extension: '.mjs'}),
         // Just release me :(
         // createEntry({format: 'iife', file: pkg.browser}),
         // createEntry({format: 'cjs', file: pkg.main}),


### PR DESCRIPTION
Needed for the Vite SSR boilerplate repo (amongst other repos), this adds a UMD build which can be used more easily for building other repos. If this package would only build a ES module file, the Vite SSR repo can't make a working build