### PR TITLE
Bug/collapse opens on create

### DIFF
--- a/src/components/Alert/Alert.test.ts
+++ b/src/components/Alert/Alert.test.ts
@@ -20,7 +20,7 @@ describe('onMounted', () => {
     it('sets bsAlert', async() => {
         const wrapper = await shallowMount(Alert);
 
-        expect((await import('bootstrap')).Alert.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.alert);
+        expect((await import('bootstrap')).Alert.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.alert, {});
 
         // TODO: Unable to assert bsAlert value.
     });

--- a/src/components/Collapse/Collapse.stories.ts
+++ b/src/components/Collapse/Collapse.stories.ts
@@ -12,8 +12,14 @@ const template = (args) => ({
     setup: () => ({args}),
     template: `
         <Collapse v-bind="args">
-            <template #toggle>
-                <Btn class="mb-2">Open me</Btn>
+            <template #toggle="{id}">
+                <Btn
+                    class="mb-2"
+                    data-bs-toggle="collapse"
+                    :data-bs-target="'#' + id"
+                >
+                    Open me
+                </Btn>
             </template>
 
             <Card text="Some placeholder content for the collapse component. This panel is hidden by default but revealed when the user activates the relevant trigger." />

--- a/src/components/Collapse/Collapse.stories.ts
+++ b/src/components/Collapse/Collapse.stories.ts
@@ -12,7 +12,7 @@ const template = (args) => ({
     setup: () => ({args}),
     template: `
         <Collapse v-bind="args">
-            <template #toggle="{id}">
+            <template #toggle-content="{id}">
                 <Btn
                     class="mb-2"
                     data-bs-toggle="collapse"

--- a/src/components/Collapse/Collapse.test.ts
+++ b/src/components/Collapse/Collapse.test.ts
@@ -15,7 +15,7 @@ describe('template', () => {
 
     componentSlotRenderTest(Collapse, 'toggle');
 
-    componentSlotRenderTest(Collapse, 'toggle-content');
+    componentSlotRenderTest(Collapse, 'toggleContent');
 
     ['show', 'shown', 'hide', 'hidden'].forEach((event: string) => {
         componentBootstrapEventTest(

--- a/src/components/Collapse/Collapse.test.ts
+++ b/src/components/Collapse/Collapse.test.ts
@@ -13,7 +13,9 @@ describe('template', () => {
         props: {id: 'dont-change-please'},
     });
 
-    componentSlotRenderTest(Collapse);
+    componentSlotRenderTest(Collapse, 'toggle');
+
+    componentSlotRenderTest(Collapse, 'toggle-content');
 
     ['show', 'shown', 'hide', 'hidden'].forEach((event: string) => {
         componentBootstrapEventTest(
@@ -29,7 +31,7 @@ describe('onMounted', () => {
     it('sets bsCollapse', async() => {
         const wrapper = await shallowMount(Collapse);
 
-        expect((await import('bootstrap')).Collapse.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.collapse);
+        expect((await import('bootstrap')).Collapse.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.collapse, {toggle: false});
 
         // TODO: Unable to assert bsCollapse value.
     });

--- a/src/components/Collapse/Collapse.vue
+++ b/src/components/Collapse/Collapse.vue
@@ -54,6 +54,7 @@ useBootstrapEmits(
 const {bsInstance: bsCollapse} = useBootstrapInstance(
     'Collapse',
     collapse,
+    {toggle: false},
 );
 
 defineExpose({bsCollapse});

--- a/src/components/Collapse/Collapse.vue
+++ b/src/components/Collapse/Collapse.vue
@@ -4,7 +4,7 @@
         name="toggle"
     >
         <div
-            class="d-inline-block"
+            class="collapse-toggle"
             data-bs-toggle="collapse"
             :data-bs-target="`#${id}`"
         >

--- a/src/components/Collapse/Collapse.vue
+++ b/src/components/Collapse/Collapse.vue
@@ -7,6 +7,7 @@
             class="collapse-toggle"
             data-bs-toggle="collapse"
             :data-bs-target="`#${id}`"
+            v-bind="$attrs"
         >
             <slot
                 :id="id"

--- a/src/components/Collapse/Collapse.vue
+++ b/src/components/Collapse/Collapse.vue
@@ -1,13 +1,19 @@
 <template>
-    <div
-        class="d-inline-block"
-        data-bs-toggle="collapse"
-        :data-bs-target="`#${id}`"
+    <slot
+        :id="id"
+        name="toggle"
     >
-        <slot
-            name="toggle"
-        />
-    </div>
+        <div
+            class="d-inline-block"
+            data-bs-toggle="collapse"
+            :data-bs-target="`#${id}`"
+        >
+            <slot
+                :id="id"
+                name="toggle-content"
+            />
+        </div>
+    </slot>
 
     <div
         :id="id"
@@ -15,7 +21,7 @@
         class="collapse"
         :data-bs-parent="parentSelector"
     >
-        <slot />
+        <slot :id="id" />
     </div>
 </template>
 

--- a/src/components/Collapse/Collapse.vue
+++ b/src/components/Collapse/Collapse.vue
@@ -11,7 +11,7 @@
         >
             <slot
                 :id="id"
-                name="toggle-content"
+                name="toggleContent"
             />
         </div>
     </slot>

--- a/src/components/Collapse/__snapshots__/Collapse.test.ts.snap
+++ b/src/components/Collapse/__snapshots__/Collapse.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`template renders default 1`] = `
-"<div class=\\"d-inline-block\\" data-bs-toggle=\\"collapse\\" data-bs-target=\\"#dont-change-please\\"></div>
+"<div class=\\"collapse-toggle\\" data-bs-toggle=\\"collapse\\" data-bs-target=\\"#dont-change-please\\"></div>
 <div id=\\"dont-change-please\\" class=\\"collapse\\"></div>"
 `;

--- a/src/components/Dropdown/Dropdown.test.ts
+++ b/src/components/Dropdown/Dropdown.test.ts
@@ -59,7 +59,7 @@ describe('onMounted', () => {
     it('sets bsDropdown', async() => {
         const wrapper = await shallowMount(Dropdown);
 
-        expect((await import('bootstrap')).Dropdown.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.dropdown);
+        expect((await import('bootstrap')).Dropdown.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.dropdown, {});
 
         // TODO: Unable to assert bsDropdown value.
     });

--- a/src/components/Modal/Modal.test.ts
+++ b/src/components/Modal/Modal.test.ts
@@ -49,7 +49,7 @@ describe('onMounted', () => {
     it('sets bsModal', async() => {
         const wrapper = await shallowMount(Modal);
 
-        expect((await import('bootstrap')).Modal.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.modal);
+        expect((await import('bootstrap')).Modal.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.modal, {});
 
         // TODO: Unable to assert bsModal value.
     });

--- a/src/components/Offcanvas/Offcanvas.test.ts
+++ b/src/components/Offcanvas/Offcanvas.test.ts
@@ -48,7 +48,7 @@ describe('onMounted', () => {
     it('sets bsOffcanvas', async() => {
         const wrapper = await shallowMount(Offcanvas);
 
-        expect((await import('bootstrap')).Offcanvas.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.offcanvas);
+        expect((await import('bootstrap')).Offcanvas.getOrCreateInstance).toBeCalledWith(wrapper.vm.$refs.offcanvas, {});
 
         // TODO: Unable to assert bsOffcanvas value.
     });

--- a/src/composables/useBootstrapInstance/index.ts
+++ b/src/composables/useBootstrapInstance/index.ts
@@ -5,7 +5,7 @@ import useBootstrap from '@/composables/useBootstrap';
 type Bootstrap = typeof Bs;
 
 // TODO: Better typehinting
-const useBootstrapInstance = <K extends keyof Bootstrap>(type: K, element: Ref<string|Element|ComponentPublicInstance>, options: Record<string, any> = {}) => {
+const useBootstrapInstance = <K extends keyof Bootstrap>(type: K, element: Ref<string|Element|ComponentPublicInstance>, options: Record<string, unknown> = {}) => {
     const bootstrap = useBootstrap();
 
     const bsInstance = ref<ReturnType<Bootstrap[K]['getOrCreateInstance']>>();

--- a/src/composables/useBootstrapInstance/index.ts
+++ b/src/composables/useBootstrapInstance/index.ts
@@ -5,7 +5,7 @@ import useBootstrap from '@/composables/useBootstrap';
 type Bootstrap = typeof Bs;
 
 // TODO: Better typehinting
-const useBootstrapInstance = <K extends keyof Bootstrap>(type: K, element: Ref<string|Element|ComponentPublicInstance>) => {
+const useBootstrapInstance = <K extends keyof Bootstrap>(type: K, element: Ref<string|Element|ComponentPublicInstance>, options: Record<string, any> = {}) => {
     const bootstrap = useBootstrap();
 
     const bsInstance = ref<ReturnType<Bootstrap[K]['getOrCreateInstance']>>();
@@ -18,7 +18,7 @@ const useBootstrapInstance = <K extends keyof Bootstrap>(type: K, element: Ref<s
                 ?.[type]
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
-                .getOrCreateInstance(element.value?.$el || element.value);
+                .getOrCreateInstance(element.value?.$el || element.value, options);
         }
     });
 


### PR DESCRIPTION
Adds `options` for `useBootstrapInstance`. Useful for when you for example do not want the collapse to open on itself.

Changes the `toggle` slot on `Collapse` with `toggle-content` and wrapped the whole toggle itself with `toggle` slot.