### PR TITLE
fix(dropdownsearch): remove set undefined to avoid changing modelValue

### DIFF
--- a/src/components/FormDropdownSearch/FormDropdownSearch.vue
+++ b/src/components/FormDropdownSearch/FormDropdownSearch.vue
@@ -152,8 +152,6 @@ const searchValueDisplayed = computed({
         searchValueCached.value = '';
 
         searchValue.value = s;
-
-        modelValue.value = undefined;
     },
 });
 


### PR DESCRIPTION
This was causing problems when trying to add a `None` option, it would always select that option if there wasn't any result for the search.