### PR TITLE
fix(Tooltip): Allow ssr usage by using HTMLElement type instead of object

### DIFF
--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -22,11 +22,11 @@ type TooltipEvent = typeof tooltipEvents[number];
 <script lang="ts" setup>
 const props = defineProps({
     boundary: {
-        type: [String, HTMLElement],
+        type: [String, Object] as PropType<string | HTMLElement>,
         default: 'clippingParents',
     },
     container: {
-        type: [String, HTMLElement, Boolean],
+        type: [String, Object, Boolean] as PropType<string | HTMLElement | boolean>,
         default: false,
     },
     customClass: {


### PR DESCRIPTION
In ssr, the `HTMLElement` object is not available. For this reason we have to check the type instead of referencing the object.