### PR TITLE
feat(Carousel): allow custom control elements through slots

### DIFF
--- a/src/components/Carousel/Carousel.stories.ts
+++ b/src/components/Carousel/Carousel.stories.ts
@@ -59,3 +59,64 @@ export const Default = template.bind({});
 Default.args = {
     slides,
 };
+
+const slots = (args) => ({
+    components: {Carousel},
+    setup: () => ({args}),
+    template: `
+        <div class="container">
+            <Carousel
+                id="Carousel"
+                v-bind="args"
+            >
+                <template #control-prev="{ dataset }">
+                    <div 
+                        v-bind="dataset"
+                        style="
+                            position: absolute; 
+                            left: 10px; 
+                            top: calc(50% - 20px);
+                            width:40px;
+                            height:40px;
+                            background:green;
+                        " 
+                    />
+                </template>
+
+                <template #control-next="{ dataset }">
+                    <div 
+                        v-bind="dataset"
+                        style="
+                            position: absolute; 
+                            right: 10px; 
+                            top: calc(50% - 20px);
+                            width:40px;
+                            height:40px;
+                            background:blue;
+                        " 
+                    />
+                </template>
+
+                <template #indicator="{ index, activeIndex, slide, dataset }">
+                    <div 
+                        v-bind="dataset" 
+                        :class="{active: index === activeIndex}" 
+                        style="
+                            background: red;
+                            border-radius: 50%;
+                            width: 20px;
+                            height: 20px;
+                            border: none;
+                        "
+                    />
+                </template>
+            </Carousel>
+        </div>
+    `,
+});
+
+export const CustomSlotContent = slots.bind({});
+
+CustomSlotContent.args = {
+    slides,
+};

--- a/src/components/Carousel/Carousel.test.ts
+++ b/src/components/Carousel/Carousel.test.ts
@@ -41,6 +41,12 @@ describe('template', () => {
 
     componentSlotRenderTest(Carousel, 'caption', {props});
 
+    componentSlotRenderTest(Carousel, 'control-prev', {props});
+
+    componentSlotRenderTest(Carousel, 'control-next', {props});
+
+    componentSlotRenderTest(Carousel, 'indicator', {props});
+
     componentWrapperAttributeTest(Carousel, {props}, 'data-bs-interval', '5000');
 
     componentWrapperClassTest(Carousel, {dark: true}, 'carousel-dark');

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -67,34 +67,69 @@
         </div>
 
         <div v-if="!hideControls">
-            <button
-                class="carousel-control-prev"
-                :data-bs-target="`#${id}`"
-                data-bs-slide="prev"
+            <!--
+            @slot Renders a previous control button
+            @binding {Object} dataset Bootstrap data attributes required for controlling the carousel
+            -->
+            <slot
+                name="control-prev"
+                :dataset="{
+                    'data-bs-target': `#${id}`,
+                    'data-bs-slide': 'prev'
+                }"
             >
-                <span class="carousel-control-prev-icon" />
-            </button>
+                <button
+                    class="carousel-control-prev"
+                    :data-bs-target="`#${id}`"
+                    data-bs-slide="prev"
+                >
+                    <span class="carousel-control-prev-icon" />
+                </button>
+            </slot>
 
-            <button
-                class="carousel-control-next"
-                :data-bs-target="`#${id}`"
-                data-bs-slide="next"
+            <!--
+            @slot Renders a next control button
+            @binding {Object} dataset Bootstrap data attributes required for controlling the carousel
+            -->
+            <slot
+                name="control-next"
+                :dataset="{
+                    'data-bs-target': `#${id}`,
+                    'data-bs-slide': 'next'
+                }"
             >
-                <span class="carousel-control-next-icon" />
-            </button>
+                <button
+                    class="carousel-control-next"
+                    :data-bs-target="`#${id}`"
+                    data-bs-slide="next"
+                >
+                    <span class="carousel-control-next-icon" />
+                </button>
+            </slot>
         </div>
 
         <div
             v-if="!hideIndicators"
             class="carousel-indicators"
         >
-            <button
-                v-for="(_, index) in slides"
-                :key="`slide-indicator-${index}`"
-                :class="{active: index === activeIndex}"
-                :data-bs-target="`#${id}`"
-                :data-bs-slide-to="index"
-            />
+            <slot
+                v-for="(slide, index) in slides"
+                name="indicator"
+                :index="index"
+                :slide="slide"
+                :active-index="activeIndex"
+                :dataset="{
+                    'data-bs-target': `#${id}`,
+                    'data-bs-slide-to': index
+                }"
+            >
+                <button
+                    :key="`slide-indicator-${index}`"
+                    :class="{active: index === activeIndex}"
+                    :data-bs-target="`#${id}`"
+                    :data-bs-slide-to="index"
+                />
+            </slot>
         </div>
     </div>
 </template>

--- a/src/components/Carousel/__snapshots__/Carousel.test.ts.snap
+++ b/src/components/Carousel/__snapshots__/Carousel.test.ts.snap
@@ -56,7 +56,16 @@ exports[`template renders default 1`] = `
       </div>
     </div>
   </div>
-  <div><button class=\\"carousel-control-prev\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide=\\"prev\\"><span class=\\"carousel-control-prev-icon\\"></span></button><button class=\\"carousel-control-next\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide=\\"next\\"><span class=\\"carousel-control-next-icon\\"></span></button></div>
+  <div>
+    <!--
+            @slot Renders a previous control button
+            @binding {Object} dataset Bootstrap data attributes required for controlling the carousel
+            --><button class=\\"carousel-control-prev\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide=\\"prev\\"><span class=\\"carousel-control-prev-icon\\"></span></button>
+    <!--
+            @slot Renders a next control button
+            @binding {Object} dataset Bootstrap data attributes required for controlling the carousel
+            --><button class=\\"carousel-control-next\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide=\\"next\\"><span class=\\"carousel-control-next-icon\\"></span></button>
+  </div>
   <div class=\\"carousel-indicators\\"><button class=\\"\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide-to=\\"0\\"></button><button class=\\"active\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide-to=\\"1\\"></button><button class=\\"\\" data-bs-target=\\"#dont-change-please\\" data-bs-slide-to=\\"2\\"></button></div>
 </div>"
 `;


### PR DESCRIPTION
This PR adds named x scoped slots to the Carousel component. These slots make it possible to customize the prev/next controls, as well as the slide indicator elements.

I generated a new snapshot, added tests and added a new storybook story.