### PR TITLE
fix(Tooltip): remove tooltip when unmounted

### DIFF
--- a/src/components/Modal/Modal.vue
+++ b/src/components/Modal/Modal.vue
@@ -147,9 +147,7 @@ const {classes} = useClasses(computed(() => [
 ]));
 
 onBeforeUnmount(() => {
-    if (bsModal.value) {
-        bsModal.value.hide();
-    }
+    bsModal.value?.hide();
 });
 
 defineExpose({bsModal});

--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import {PropType, computed, ref} from 'vue';
+import {PropType, computed, onBeforeUnmount, ref} from 'vue';
 import {tooltipFallbackPlacementProps, tooltipPlacementProps} from '@/composables/useTooltipPlacement';
 import {triggerProps} from '@/composables/useTrigger';
 import useBootstrapEmits from '@/composables/useBootstrapEmits';
@@ -132,6 +132,10 @@ const {bsInstance: bsTooltip} = useBootstrapInstance(
         trigger: tooltipTriggers.value,
     },
 );
+
+onBeforeUnmount(() => {
+    bsTooltip.value?.dispose();
+});
 
 defineExpose({bsTooltip});
 </script>


### PR DESCRIPTION
This can't be tested, since there is no way the `bsTooltip` can be accessed from the tests (it is always `undefined`). We should fix this, since we also get this behavior when using the package in another project.