### PR TITLE
fix(FormControl): fix missing passthrough of required

### DIFF
--- a/src/components/FormControl/FormControl.test.ts
+++ b/src/components/FormControl/FormControl.test.ts
@@ -36,6 +36,14 @@ describe('template', () => {
         expect((wrapper.element as HTMLInputElement).readOnly).toBe(true);
     });
 
+    it('adds required property', () => {
+        const wrapper = shallowMount(FormControl, {
+            props: {required: true},
+        });
+
+        expect((wrapper.element as HTMLInputElement).required).toBe(true);
+    });
+
     componentWrapperClassTest(FormControl, {disabled: true}, 'disabled');
 
     componentWrapperClassTest(FormControl, {plainText: true}, 'form-control-plaintext');

--- a/src/components/FormControl/FormControl.vue
+++ b/src/components/FormControl/FormControl.vue
@@ -7,6 +7,7 @@
         :disabled="disabled"
         :placeholder="placeholder"
         :readonly="readonly"
+        :required="required"
         :type="type"
         :value="modelValue"
         @input="emit('update:modelValue', $event.target.value)"


### PR DESCRIPTION
#87 forgot to pass required through the `input` element.