### PR TITLE
fix(useVariant): allow custom variants

### DIFF
--- a/src/composables/useVariant/index.ts
+++ b/src/composables/useVariant/index.ts
@@ -3,7 +3,7 @@ import useStringTemplate from '@/composables/useStringTemplate';
 
 export const variants = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'light', 'dark', 'link'] as const;
 
-export type Variant = typeof variants[number];
+export type Variant = typeof variants[number] | string;
 
 export default (variant: MaybeRef<Variant>, classTemplate: MaybeRef<string>) => {
     const {templatedString} = useStringTemplate(classTemplate, variant);
@@ -15,7 +15,6 @@ export const variantProp = (defaultValue: Variant | '' | undefined = 'primary') 
     return {
         type: String as PropType<Variant>,
         default: defaultValue,
-        validator: (v?: Variant) => v ? variants.includes(v) : true,
     };
 };
 

--- a/src/composables/useVariant/useVariant.test.ts
+++ b/src/composables/useVariant/useVariant.test.ts
@@ -1,29 +1,5 @@
 import useVariant, {variantProp, variantProps, variants} from '.';
 
-describe('variantProps', () => {
-    describe('variant', () => {
-        variants.forEach((s) => {
-            it(`passes validation with ${s}`, () => {
-                const result = variantProps.variant.validator(s);
-
-                expect(result).toBe(true);
-            });
-        });
-
-        it('passes validation with empty value', () => {
-            const result = variantProps.variant.validator(undefined);
-
-            expect(result).toBe(true);
-        });
-
-        it('passes validation with a non variant', () => {
-            const result = variantProps.variant.validator('non-variant');
-
-            expect(result).toBe(false);
-        });
-    });
-});
-
 describe('variantProp', () => {
     it('sets the default value', () => {
         const prop = variantProp('');

--- a/src/composables/useVariant/useVariant.test.ts
+++ b/src/composables/useVariant/useVariant.test.ts
@@ -1,4 +1,4 @@
-import useVariant, {variantProp, variantProps, variants} from '.';
+import useVariant, {variantProp} from '.';
 
 describe('variantProp', () => {
     it('sets the default value', () => {


### PR DESCRIPTION
If you have a custom variant (ie. `white`), it will currently cause warnings to show up, even though they are valid.