### PR TITLE
fix(Tooltip): allow using numbers as the content of a tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.vue
+++ b/src/components/Tooltip/Tooltip.vue
@@ -82,7 +82,7 @@ const props = defineProps({
      * The text to display in the tooltip
      */
     title: {
-        type: String,
+        type: [String, Number],
         default: '',
     },
     ...tooltipFallbackPlacementProps,


### PR DESCRIPTION
The title prop could be just a number, otherwise you'll have to do `String(num)` every time you just want to show a simple number.