### PR TITLE
fix: make storybook build work again

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,6 @@
 import type { StorybookConfig } from "@storybook/vue3-vite";
+import { mergeConfig } from "vite";
+import { viteStaticCopy as Copy } from 'vite-plugin-static-copy';
 
 const config: StorybookConfig = {
     stories: [
@@ -22,13 +24,13 @@ const config: StorybookConfig = {
         options: {},
     },
     viteFinal: (config, options) => {
-        config.plugins = config.plugins?.filter(async (plugin) => {
-            plugin = await plugin;
-
-            return typeof plugin === 'boolean' || Array.isArray(plugin) || plugin?.name !== 'vite-plugin-static-copy:build';
+        return mergeConfig(config, {
+            // This is needed because the copy plugin can't copy files outside of the root directory
+            // The files are copied back to the root by the post script
+            build: {
+                outDir: 'storybook-static/dist'
+            }
         });
-
-        return config;
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
         "lint": "eslint src --ext .ts,.vue",
         "generate-docs": "vue-docgen -c docgen.config.cjs",
         "postversion": "cp package.json ..",
-        "predeploy": "storybook build",
+        "predeploy": "yarn storybook:build",
         "storybook": "storybook dev -p 6006",
         "storybook:build": "NODE_OPTIONS=--openssl-legacy-provider storybook build",
+        "poststorybook:build": "cp -r ./storybook-static/dist/** ./storybook-static && rm -rf ./storybook-static/dist",
         "storybook:deploy": "gh-pages -d storybook-static"
     },
     "devDependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import DTS from "vite-plugin-dts";
-import { viteStaticCopy as Copy } from 'vite-plugin-static-copy'
+import { viteStaticCopy as Copy } from 'vite-plugin-static-copy';
 import VueDocgen from './vite/plugin-docgen';
 import Delete from './vite/plugin-delete';
 


### PR DESCRIPTION
The vite copy plugin is conflicting with the storybook build, so we build into a subdirectory and after the build copy it back into the storybook root